### PR TITLE
RoundTrip: don't override any existing `Accept` header, add on to it

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -94,7 +94,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	req.Header.Set("Authorization", "token "+token)
-	req.Header.Set("Accept", acceptHeader)
+	req.Header.Add("Accept", acceptHeader)
 	resp, err := t.tr.RoundTrip(req)
 	return resp, err
 }


### PR DESCRIPTION
currently if I want to use a github preview api I need to set a specific `Accept` header but `RoundTrip` overrides whatever I set in my request with its own `Accept` header.  This change just adds on to existing `Accept` headers and doesn't override them.