### PR TITLE
Split authentication as an app into AppsTransport

### DIFF
--- a/appsTransport.go
+++ b/appsTransport.go
@@ -1,0 +1,59 @@
+package ghinstallation
+
+import (
+	"crypto/rsa"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	jwt "github.com/dgrijalva/jwt-go"
+)
+
+type AppsTransport struct {
+	BaseURL       string            // baseURL is the scheme and host for GitHub API, defaults to https://api.github.com
+	Client        Client            // Client to use to refresh tokens, defaults to http.Client with provided transport
+	tr            http.RoundTripper // tr is the underlying roundtripper being wrapped
+	key           *rsa.PrivateKey   // key is the GitHub Integration's private key
+	integrationID int               // integrationID is the GitHub Integration's Installation ID
+}
+
+func NewAppsTransport(tr http.RoundTripper, integrationID int, privateKey []byte) (*AppsTransport, error) {
+	t := &AppsTransport{
+		tr:            tr,
+		integrationID: integrationID,
+		BaseURL:       apiBaseURL,
+		Client:        &http.Client{Transport: tr},
+	}
+	var err error
+	t.key, err = jwt.ParseRSAPrivateKeyFromPEM(privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse private key: %s", err)
+	}
+	return t, nil
+}
+
+// RoundTrip implements http.RoundTripper interface.
+func (t *AppsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+
+	// TODO check expiry
+
+	// TODO these claims could probably be reused between installations before expiry
+	claims := &jwt.StandardClaims{
+		IssuedAt:  time.Now().Unix(),
+		ExpiresAt: time.Now().Add(time.Minute).Unix(),
+		Issuer:    strconv.Itoa(t.integrationID),
+	}
+	bearer := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+
+	ss, err := bearer.SignedString(t.key)
+	if err != nil {
+		return nil, fmt.Errorf("could not sign jwt: %s", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+ss)
+	req.Header.Set("Accept", acceptHeader)
+
+	resp, err := t.tr.RoundTrip(req)
+	return resp, err
+}

--- a/appsTransport_test.go
+++ b/appsTransport_test.go
@@ -1,0 +1,28 @@
+package ghinstallation
+
+import (
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+)
+
+func TestNewAppsTransportKeyFromFile(t *testing.T) {
+	tmpfile, err := ioutil.TempFile("", "example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	if _, err := tmpfile.Write(key); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = NewAppsTransportKeyFromFile(&http.Transport{}, integrationID, tmpfile.Name())
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+}

--- a/transport.go
+++ b/transport.go
@@ -16,7 +16,7 @@ const (
 )
 
 // Transport provides a http.RoundTripper by wrapping an existing
-// http.RoundTripper and provides GitHub Integration authentication as an
+// http.RoundTripper and provides GitHub Apps authentication as an
 // installation.
 //
 // Client can also be overwritten, and is useful to change to one which
@@ -43,7 +43,7 @@ type accessToken struct {
 
 var _ http.RoundTripper = &Transport{}
 
-// NewKeyFromFile returns an Transport using a private key from file.
+// NewKeyFromFile returns a Transport using a private key from file.
 func NewKeyFromFile(tr http.RoundTripper, integrationID, installationID int, privateKeyFile string) (*Transport, error) {
 	privateKey, err := ioutil.ReadFile(privateKeyFile)
 	if err != nil {
@@ -59,7 +59,7 @@ type Client interface {
 }
 
 // New returns an Transport using private key. The key is parsed
-// and if any errors occur the transport is nil and error is non-nil.
+// and if any errors occur the error is non-nil.
 //
 // The provided tr http.RoundTripper should be shared between multiple
 // installations to ensure reuse of underlying TCP connections.


### PR DESCRIPTION
Splits authentication as a GitHub App into an `AppsTransport` which implements `http.RoundTripper`. Note this is a WIP, and requires documentation and closer review for cleanup.

For review by @itay.

Resolves #6.