### PR TITLE
Robust Header Check

### DIFF
--- a/appsTransport.go
+++ b/appsTransport.go
@@ -73,9 +73,8 @@ func (t *AppsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	req.Header.Set("Authorization", "Bearer "+ss)
-	addAcceptHeader(req)
+	addAcceptHeader(req.Header)
 
 	resp, err := t.tr.RoundTrip(req)
 	return resp, err
-
 }

--- a/appsTransport.go
+++ b/appsTransport.go
@@ -73,8 +73,9 @@ func (t *AppsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	req.Header.Set("Authorization", "Bearer "+ss)
-	req.Header.Set("Accept", acceptHeader)
+	addAcceptHeader(req)
 
 	resp, err := t.tr.RoundTrip(req)
 	return resp, err
+
 }

--- a/transport.go
+++ b/transport.go
@@ -142,7 +142,7 @@ func addAcceptHeader(headers http.Header) {
 		return
 	}
 
-	//Need to loop through all Accept headers incase there is more than one.
+	//Need to loop through all Accept headers in case there is more than one.
 	for _, header := range headers["Accept"] {
 		//Looks as though all media types (https://developer.github.com/v3/media/) that can accept json end with "json". 
 		//Only doing a suffix check to see if a json header already exists.

--- a/transport.go
+++ b/transport.go
@@ -1,6 +1,7 @@
 package ghinstallation
 
 import (
+	"strings"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -141,7 +142,7 @@ func addAcceptHeader(req *http.Request) {
 	if req.Header.Get("Accept") != "" {
 		//Need to loop through all Accept headers incase there is more than one.
 		for headerName, headers := range req.Header {
-			if headerName == "Accept" {
+			if strings.ToLower(headerName) == "accept" {
 				for _, header := range headers {
 					if header == defaultMediaType {
 						//Do not add any other Accept header if 'application/octet-stream' is present. More than one will prevent a download API call from succeeding

--- a/transport.go
+++ b/transport.go
@@ -91,7 +91,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	req.Header.Set("Authorization", "token "+token)
-	addAcceptHeader(req)
+	addAcceptHeader(req.Header)
 	resp, err := t.tr.RoundTrip(req)
 	return resp, err
 }
@@ -136,21 +136,18 @@ func (t *Transport) refreshToken() error {
 	return nil
 }
 
-func addAcceptHeader(req *http.Request) {
-	if req.Header.Get("Accept") != "" {
-		//Need to loop through all Accept headers incase there is more than one.
-		for headerName, headers := range req.Header {
-			if strings.ToLower(headerName) == "accept" {
-				for _, header := range headers {
-					//Looks as though all media types (https://developer.github.com/v3/media/) that can accept json end with "json". Only doing a suffix check to see if a json header already exists.
-					if strings.HasSuffix(header, "json") {
-						req.Header.Add("Accept", acceptHeader) // We add to "Accept" header to avoid overwriting existing req headers.
-						return
-					}
-				}
-			}
+func addAcceptHeader(headers http.Header) {
+	if headers.Get("Accept") == "" {
+		headers.Set("Accept", acceptHeader)
+		return
+	}
+
+	//Need to loop through all Accept headers incase there is more than one.
+	for _, header := range headers["Accept"] {
+		//Looks as though all media types (https://developer.github.com/v3/media/) that can accept json end with "json". Only doing a suffix check to see if a json header already exists.
+		if strings.HasSuffix(header, "json") {
+			headers.Add("Accept", acceptHeader) // We add to "Accept" header to avoid overwriting existing req headers.
+			return
 		}
-	} else {
-		req.Header.Add("Accept", acceptHeader) // We add to "Accept" header to avoid overwriting existing req headers.
 	}
 }

--- a/transport.go
+++ b/transport.go
@@ -142,7 +142,6 @@ func (t *Transport) refreshToken() error {
 
 func addAcceptHeader(req *http.Request) {
 	//Check to see if we're making a single asset GET request
-	fmt.Println(req.URL.Path)
 	if req.Method == http.MethodGet && assetPathRegex.MatchString(req.URL.Path) {
 		if req.Header.Get("Accept") != defaultMediaType {
 			req.Header.Add("Accept", acceptHeader) // We add to "Accept" header to avoid overwriting existing req headers.

--- a/transport.go
+++ b/transport.go
@@ -18,7 +18,7 @@ const (
 )
 
 //Used to detect if a single asset request is being made. https://developer.github.com/v3/repos/releases/#get-a-single-release-asset
-var assetPathRegex = regexp.MustCompile("/repos/.+/.+/releases/assets/\\d+")
+var assetPathRegex = regexp.MustCompile("/repos/.+/.+/releases/assets/[0-9]+")
 
 // Transport provides a http.RoundTripper by wrapping an existing
 // http.RoundTripper and provides GitHub Apps authentication as an

--- a/transport.go
+++ b/transport.go
@@ -136,6 +136,8 @@ func (t *Transport) refreshToken() error {
 	return nil
 }
 
+// addAcceptHeader adds acceptHeader value to "Accept" header, but only
+// if the current "Accept" header is not set, or if it already accepts JSON.
 func addAcceptHeader(headers http.Header) {
 	if headers.Get("Accept") == "" {
 		headers.Set("Accept", acceptHeader)

--- a/transport.go
+++ b/transport.go
@@ -144,7 +144,8 @@ func addAcceptHeader(headers http.Header) {
 
 	//Need to loop through all Accept headers incase there is more than one.
 	for _, header := range headers["Accept"] {
-		//Looks as though all media types (https://developer.github.com/v3/media/) that can accept json end with "json". Only doing a suffix check to see if a json header already exists.
+		//Looks as though all media types (https://developer.github.com/v3/media/) that can accept json end with "json". 
+		//Only doing a suffix check to see if a json header already exists.
 		if strings.HasSuffix(header, "json") {
 			headers.Add("Accept", acceptHeader) // We add to "Accept" header to avoid overwriting existing req headers.
 			return

--- a/transport.go
+++ b/transport.go
@@ -144,10 +144,10 @@ func addAcceptHeader(headers http.Header) {
 		return
 	}
 
-	//Need to loop through all Accept headers in case there is more than one.
+	// Need to loop through all Accept headers in case there is more than one.
 	for _, header := range headers["Accept"] {
-		//Looks as though all media types (https://developer.github.com/v3/media/) that can accept json end with "json". 
-		//Only doing a suffix check to see if a json header already exists.
+		// Looks as though all media types (https://developer.github.com/v3/media/) that can accept json end with "json". 
+		// Only doing a suffix check to see if a json header already exists.
 		if strings.HasSuffix(header, "json") {
 			headers.Add("Accept", acceptHeader) // We add to "Accept" header to avoid overwriting existing req headers.
 			return

--- a/transport.go
+++ b/transport.go
@@ -1,11 +1,11 @@
 package ghinstallation
 
 import (
-	"strings"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 )

--- a/transport_test.go
+++ b/transport_test.go
@@ -183,7 +183,7 @@ func TestSingleAssetBinary_AddAcceptHeader(t *testing.T) {
 
 	req.Header.Set("Accept", "application/octet-stream")
 
-	addAcceptHeader(req)
+	addAcceptHeader(req.Header)
 
 	for headerName, headers := range req.Header {
 		if strings.ToLower(headerName) == "accept" {
@@ -203,7 +203,7 @@ func TestNormal_AddAcceptHeader(t *testing.T) {
 		t.Fatalf("Failed to create test request: %s", err.Error())
 	}
 
-	addAcceptHeader(req)
+	addAcceptHeader(req.Header)
 
 	if req.Header.Get("Accept") != acceptHeader {
 		t.Error("Did not correctly set 'Accept' header")
@@ -216,9 +216,9 @@ func TestAlreadyExists_AddAcceptHeader(t *testing.T) {
 		t.Fatalf("Failed to create test request: %s", err.Error())
 	}
 
-	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("accept", "application/vnd.github.v3+json")
 
-	addAcceptHeader(req)
+	addAcceptHeader(req.Header)
 
 	found := false
 	for headerName, headers := range req.Header {
@@ -243,7 +243,7 @@ func TestSingleAssetJSON_AddAcceptHeader(t *testing.T) {
 		t.Fatalf("Failed to create test request: %s", err.Error())
 	}
 
-	addAcceptHeader(req)
+	addAcceptHeader(req.Header)
 
 	if req.Header.Get("Accept") != acceptHeader {
 		t.Error("Did not correctly set 'Accept' header")

--- a/transport_test.go
+++ b/transport_test.go
@@ -181,7 +181,7 @@ func TestSingleAssetBinary_AddAcceptHeader(t *testing.T) {
 		t.Fatalf("Failed to create test request: %s", err.Error())
 	}
 
-	req.Header.Set("Accept", defaultMediaType)
+	req.Header.Set("Accept", "application/octet-stream")
 
 	addAcceptHeader(req)
 
@@ -207,6 +207,33 @@ func TestNormal_AddAcceptHeader(t *testing.T) {
 
 	if req.Header.Get("Accept") != acceptHeader {
 		t.Error("Did not correctly set 'Accept' header")
+	}
+}
+
+func TestAlreadyExists_AddAcceptHeader(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://api.github.com/repos", http.NoBody)
+	if err != nil {
+		t.Fatalf("Failed to create test request: %s", err.Error())
+	}
+
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	addAcceptHeader(req)
+
+	found := false
+	for headerName, headers := range req.Header {
+		if strings.ToLower(headerName) == "accept" {
+			for _, header := range headers {
+				if header == acceptHeader {
+					found = true
+					break
+				}
+			}
+		}
+	}
+
+	if !found {
+		t.Errorf("Did not correctly append %s header", acceptHeader)
 	}
 }
 

--- a/transport_test.go
+++ b/transport_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -171,5 +172,53 @@ func TestNew_appendHeader(t *testing.T) {
 
 	if !found {
 		t.Errorf("could not find %v in request's accept headers: %v", myheader, headers["Accept"])
+	}
+}
+
+func TestSingleAssetBinary_AddAcceptHeader(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://api.github.com/repos/bradleyfalzon/ghinstallation/releases/assets/1", http.NoBody)
+	if err != nil {
+		t.Fatalf("Failed to create test request: %s", err.Error())
+	}
+
+	req.Header.Set("Accept", defaultMediaType)
+
+	addAcceptHeader(req)
+
+	for headerName, headers := range req.Header {
+		if strings.ToLower(headerName) == "accept" {
+			for _, header := range headers {
+				if header == acceptHeader {
+					fmt.Printf("Header Name: %s, Header: %s", headerName, header)
+					t.Error("Set Accept header improperly for single asset call")
+				}
+			}
+		}
+	}
+}
+
+func TestNormal_AddAcceptHeader(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://api.github.com/repos", http.NoBody)
+	if err != nil {
+		t.Fatalf("Failed to create test request: %s", err.Error())
+	}
+
+	addAcceptHeader(req)
+
+	if req.Header.Get("Accept") != acceptHeader {
+		t.Error("Did not correctly set 'Accept' header")
+	}
+}
+
+func TestSingleAssetJSON_AddAcceptHeader(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://api.github.com/repos/bradleyfalzon/ghinstallation/releases/assets/1", http.NoBody)
+	if err != nil {
+		t.Fatalf("Failed to create test request: %s", err.Error())
+	}
+
+	addAcceptHeader(req)
+
+	if req.Header.Get("Accept") != acceptHeader {
+		t.Error("Did not correctly set 'Accept' header")
 	}
 }


### PR DESCRIPTION
Added a robust check when adding the `Accept` Header, if an `Accept` header already exists with the value `application/octet-stream` then don't add the additional `Accept` header.

Resolves #12