### PR TITLE
Propagate context on token refresh requests

### DIFF
--- a/appsTransport.go
+++ b/appsTransport.go
@@ -20,7 +20,7 @@ import (
 //
 // See https://developer.github.com/apps/building-integrations/setting-up-and-registering-github-apps/about-authentication-options-for-github-apps/
 type AppsTransport struct {
-	BaseURL       string            // baseURL is the scheme and host for GitHub API, defaults to https://api.github.com
+	BaseURL       string            // BaseURL is the scheme and host for GitHub API, defaults to https://api.github.com
 	Client        Client            // Client to use to refresh tokens, defaults to http.Client with provided transport
 	tr            http.RoundTripper // tr is the underlying roundtripper being wrapped
 	key           *rsa.PrivateKey   // key is the GitHub Integration's private key


### PR DESCRIPTION
Pass the context of the GitHub API request to the token refresh request. I think this will also solve the underlying issue in #8. I have used this patch successfully in a side project that implemented a custom RoundTripper. My code was barfing because it expected a context on all requests and token refreshes did not have a context associated with them.