### PR TITLE
Add support for github enterprise

### DIFF
--- a/options.go
+++ b/options.go
@@ -1,0 +1,14 @@
+package ghinstallation
+
+// Option is a functional parameter interface used by the constructor
+type Option func(*Transport) error
+
+// WithEnterpriseGithub is a functional parameter to configure a custom github API server.
+func WithEnterpriseGithub(baseURL string) Option {
+	return func(transport *Transport) error {
+		if baseURL != "" {
+			transport.BaseURL = baseURL
+		}
+		return nil
+	}
+}

--- a/transport_test.go
+++ b/transport_test.go
@@ -173,3 +173,16 @@ func TestNew_appendHeader(t *testing.T) {
 		t.Errorf("could not find %v in request's accept headers: %v", myheader, headers["Accept"])
 	}
 }
+
+func TestWithEnterpriseGithub(t *testing.T) {
+	enterpriseGithub := "https://github.company.com/api/v3"
+	tr, err := New(&http.Transport{}, integrationID, installationID, key, WithEnterpriseGithub(enterpriseGithub))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if tr.BaseURL != enterpriseGithub {
+		t.Fatalf("unexpected github base URL. Expected %s, got %s", enterpriseGithub, tr.BaseURL)
+	}
+}
+


### PR DESCRIPTION
Current problem with the code is that github baseURL hardcoded to `https://api.github.com`. However, we are using enterprise version of github and the base URL is different.

If applied, this PR will add ability to support enterprise github without breaking the existing constructor interface. This is done by introducing a functional [parameter (option)](https://halls-of-valhalla.org/beta/articles/functional-options-pattern-in-go,54/).

The change adds an interface for a functional parameter called `Option`.
I've also implemented a parameter `WithEnterpriseGithub` which gives ability to override the github base URL.

**Note** This change will not break existing users of this package. It will only add option to override the github base URL.