### PR TITLE
Update GitHub App Installation Access Token Route

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -111,7 +111,7 @@ func (t *Transport) Token() (string, error) {
 }
 
 func (t *Transport) refreshToken() error {
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/installations/%v/access_tokens", t.BaseURL, t.installationID), nil)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/app/installations/%v/access_tokens", t.BaseURL, t.installationID), nil)
 	if err != nil {
 		return fmt.Errorf("could not create request: %s", err)
 	}

--- a/transport_test.go
+++ b/transport_test.go
@@ -53,7 +53,7 @@ func TestNew(t *testing.T) {
 			t.Fatalf("Request URI %q accept header got %q want: %q", r.RequestURI, r.Header.Get("Accept"), acceptHeader)
 		}
 		switch r.RequestURI {
-		case fmt.Sprintf("/installations/%d/access_tokens", installationID):
+		case fmt.Sprintf("/app/installations/%d/access_tokens", installationID):
 			// respond with any token to installation transport
 			js, _ := json.Marshal(accessToken{
 				Token:     token,


### PR DESCRIPTION
/installations/:installation_id/access_tokens is deprecated for
/apps/installations/:installation_id/access_tokens.

See
https://developer.github.com/changes/2018-08-16-renaming-and-deprecation-of-github-app-installation-access-token-route/
for more details.