### PR TITLE
AppsTransport: Do not override Accept headers.

### DIFF
--- a/appsTransport.go
+++ b/appsTransport.go
@@ -73,7 +73,7 @@ func (t *AppsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	req.Header.Set("Authorization", "Bearer "+ss)
-	req.Header.Set("Accept", acceptHeader)
+	req.Header.Add("Accept", acceptHeader)
 
 	resp, err := t.tr.RoundTrip(req)
 	return resp, err

--- a/appsTransport_test.go
+++ b/appsTransport_test.go
@@ -1,10 +1,14 @@
 package ghinstallation
 
 import (
+	"bytes"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestNewAppsTransportKeyFromFile(t *testing.T) {
@@ -25,4 +29,41 @@ func TestNewAppsTransportKeyFromFile(t *testing.T) {
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
+}
+
+type RoundTrip struct {
+	rt func(*http.Request) (*http.Response, error)
+}
+
+func (r RoundTrip) RoundTrip(req *http.Request) (*http.Response, error) {
+	return r.rt(req)
+}
+
+func TestAppsTransport(t *testing.T) {
+	customHeader := "my-header"
+	check := RoundTrip{
+		rt: func(req *http.Request) (*http.Response, error) {
+			h, ok := req.Header["Accept"]
+			if !ok {
+				t.Error("Header Accept not set")
+			}
+			want := []string{customHeader, acceptHeader}
+			if diff := cmp.Diff(want, h); diff != "" {
+				t.Errorf("HTTP Accept headers want->got: %s", diff)
+			}
+			return nil, nil
+		},
+	}
+
+	tr, err := NewAppsTransport(check, integrationID, key)
+	if err != nil {
+		t.Fatalf("error creating transport: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com", new(bytes.Buffer))
+	req.Header.Add("Accept", customHeader)
+	if _, err := tr.RoundTrip(req); err != nil {
+		t.Fatalf("error calling RoundTrip: %v", err)
+	}
+
 }


### PR DESCRIPTION
Certain Apps endpoints require a different Accept header for early
access.