### PR TITLE
Change Integration ID -> App ID to match GitHub documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 [![GoDoc](https://godoc.org/github.com/bradleyfalzon/ghinstallation?status.svg)](https://godoc.org/github.com/bradleyfalzon/ghinstallation)
 
-`ghinstallation` provides `Transport`, which implements `http.RoundTripper` to provide authentication as an installation
-for GitHub Apps.
+`ghinstallation` provides `Transport`, which implements `http.RoundTripper` to
+provide authentication as an installation for GitHub Apps.
 
-This library is designed to provide automatic authentication for https://github.com/google/go-github or your own HTTP
-client.
+This library is designed to provide automatic authentication for
+https://github.com/google/go-github or your own HTTP client.
 
-See https://developer.github.com/apps/building-integrations/setting-up-and-registering-github-apps/about-authentication-options-for-github-apps/
+See
+https://developer.github.com/apps/building-integrations/setting-up-and-registering-github-apps/about-authentication-options-for-github-apps/
 
 # Example
 
@@ -27,7 +28,7 @@ func main() {
     // Shared transport to reuse TCP connections.
     tr := http.DefaultTransport
 
-    // Wrap the shared transport for use with the integration ID 1 authenticating with installation ID 99.
+    // Wrap the shared transport for use with the app ID 1 authenticating with installation ID 99.
     itr, err := ghinstallation.NewKeyFromFile(tr, 1, 99, "2016-10-19.private-key.pem")
     if err != nil {
         log.Fatal(err)
@@ -38,14 +39,16 @@ func main() {
 }
 ```
 
-## What is integration ID and installation ID
-`integration ID` is GitHub App ID.  
-You can check as following :  
-Settings > Developer > settings > GitHub App > About item 
+## What is app ID and installation ID
 
-`installation ID` is a part of WebHook request.  
-You can get the number to check the request.  
-Settings > Developer > settings > GitHub Apps > Advanced > Payload in Request tab
+`app ID` is the GitHub App ID. \
+You can check as following : \
+Settings > Developer > settings > GitHub App > About item
+
+`installation ID` is a part of WebHook request. \
+You can get the number to check the request. \
+Settings > Developer > settings > GitHub Apps > Advanced > Payload in Request
+tab
 
 ```
 WebHook request
@@ -55,11 +58,10 @@ WebHook request
   }
 ```
 
-
 # License
 
 [Apache 2.0](LICENSE)
 
 # Dependencies
 
-- [github.com/dgrijalva/jwt-go](https://github.com/dgrijalva/jwt-go)
+-   [github.com/dgrijalva/jwt-go](https://github.com/dgrijalva/jwt-go)

--- a/appsTransport.go
+++ b/appsTransport.go
@@ -20,20 +20,20 @@ import (
 //
 // See https://developer.github.com/apps/building-integrations/setting-up-and-registering-github-apps/about-authentication-options-for-github-apps/
 type AppsTransport struct {
-	BaseURL       string            // BaseURL is the scheme and host for GitHub API, defaults to https://api.github.com
-	Client        Client            // Client to use to refresh tokens, defaults to http.Client with provided transport
-	tr            http.RoundTripper // tr is the underlying roundtripper being wrapped
-	key           *rsa.PrivateKey   // key is the GitHub Integration's private key
-	integrationID int               // integrationID is the GitHub Integration's Installation ID
+	BaseURL string            // BaseURL is the scheme and host for GitHub API, defaults to https://api.github.com
+	Client  Client            // Client to use to refresh tokens, defaults to http.Client with provided transport
+	tr      http.RoundTripper // tr is the underlying roundtripper being wrapped
+	key     *rsa.PrivateKey   // key is the GitHub App's private key
+	appID   int               // appID is the GitHub App's ID
 }
 
 // NewAppsTransportKeyFromFile returns a AppsTransport using a private key from file.
-func NewAppsTransportKeyFromFile(tr http.RoundTripper, integrationID int, privateKeyFile string) (*AppsTransport, error) {
+func NewAppsTransportKeyFromFile(tr http.RoundTripper, appID int, privateKeyFile string) (*AppsTransport, error) {
 	privateKey, err := ioutil.ReadFile(privateKeyFile)
 	if err != nil {
 		return nil, fmt.Errorf("could not read private key: %s", err)
 	}
-	return NewAppsTransport(tr, integrationID, privateKey)
+	return NewAppsTransport(tr, appID, privateKey)
 }
 
 // NewAppsTransport returns a AppsTransport using private key. The key is parsed
@@ -43,12 +43,12 @@ func NewAppsTransportKeyFromFile(tr http.RoundTripper, integrationID int, privat
 // installations to ensure reuse of underlying TCP connections.
 //
 // The returned Transport's RoundTrip method is safe to be used concurrently.
-func NewAppsTransport(tr http.RoundTripper, integrationID int, privateKey []byte) (*AppsTransport, error) {
+func NewAppsTransport(tr http.RoundTripper, appID int, privateKey []byte) (*AppsTransport, error) {
 	t := &AppsTransport{
-		tr:            tr,
-		integrationID: integrationID,
-		BaseURL:       apiBaseURL,
-		Client:        &http.Client{Transport: tr},
+		tr:      tr,
+		appID:   appID,
+		BaseURL: apiBaseURL,
+		Client:  &http.Client{Transport: tr},
 	}
 	var err error
 	t.key, err = jwt.ParseRSAPrivateKeyFromPEM(privateKey)
@@ -63,7 +63,7 @@ func (t *AppsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	claims := &jwt.StandardClaims{
 		IssuedAt:  time.Now().Unix(),
 		ExpiresAt: time.Now().Add(time.Minute).Unix(),
-		Issuer:    strconv.Itoa(t.integrationID),
+		Issuer:    strconv.Itoa(t.appID),
 	}
 	bearer := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 

--- a/appsTransport_test.go
+++ b/appsTransport_test.go
@@ -21,7 +21,7 @@ func TestNewAppsTransportKeyFromFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = NewAppsTransportKeyFromFile(&http.Transport{}, integrationID, tmpfile.Name())
+	_, err = NewAppsTransportKeyFromFile(&http.Transport{}, appID, tmpfile.Name())
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}

--- a/transport.go
+++ b/transport.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	// acceptHeader is the GitHub Integrations Preview Accept header.
+	// acceptHeader is the GitHub Apps Preview Accept header.
 	acceptHeader = "application/vnd.github.machine-man-preview+json"
 	apiBaseURL   = "https://api.github.com"
 )
@@ -27,8 +27,8 @@ type Transport struct {
 	BaseURL        string            // BaseURL is the scheme and host for GitHub API, defaults to https://api.github.com
 	Client         Client            // Client to use to refresh tokens, defaults to http.Client with provided transport
 	tr             http.RoundTripper // tr is the underlying roundtripper being wrapped
-	integrationID  int               // integrationID is the GitHub Integration's Installation ID
-	installationID int               // installationID is the GitHub Integration's Installation ID
+	appID          int               // appID is the GitHub App's ID
+	installationID int               // installationID is the GitHub App Installation ID
 	appsTransport  *AppsTransport
 
 	mu    *sync.Mutex  // mu protects token
@@ -44,12 +44,12 @@ type accessToken struct {
 var _ http.RoundTripper = &Transport{}
 
 // NewKeyFromFile returns a Transport using a private key from file.
-func NewKeyFromFile(tr http.RoundTripper, integrationID, installationID int, privateKeyFile string) (*Transport, error) {
+func NewKeyFromFile(tr http.RoundTripper, appID, installationID int, privateKeyFile string) (*Transport, error) {
 	privateKey, err := ioutil.ReadFile(privateKeyFile)
 	if err != nil {
 		return nil, fmt.Errorf("could not read private key: %s", err)
 	}
-	return New(tr, integrationID, installationID, privateKey)
+	return New(tr, appID, installationID, privateKey)
 }
 
 // Client is a HTTP client which sends a http.Request and returns a http.Response
@@ -65,17 +65,17 @@ type Client interface {
 // installations to ensure reuse of underlying TCP connections.
 //
 // The returned Transport's RoundTrip method is safe to be used concurrently.
-func New(tr http.RoundTripper, integrationID, installationID int, privateKey []byte) (*Transport, error) {
+func New(tr http.RoundTripper, appID, installationID int, privateKey []byte) (*Transport, error) {
 	t := &Transport{
 		tr:             tr,
-		integrationID:  integrationID,
+		appID:          appID,
 		installationID: installationID,
 		BaseURL:        apiBaseURL,
 		Client:         &http.Client{Transport: tr},
 		mu:             &sync.Mutex{},
 	}
 	var err error
-	t.appsTransport, err = NewAppsTransport(t.tr, t.integrationID, privateKey)
+	t.appsTransport, err = NewAppsTransport(t.tr, t.appID, privateKey)
 	if err != nil {
 		return nil, err
 	}

--- a/transport_test.go
+++ b/transport_test.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	installationID = 1
-	integrationID  = 2
+	appID          = 2
 	token          = "abc123"
 )
 
@@ -71,7 +71,7 @@ func TestNew(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	tr, err := New(&http.Transport{}, integrationID, installationID, key)
+	tr, err := New(&http.Transport{}, appID, installationID, key)
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -127,7 +127,7 @@ func TestNewKeyFromFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = NewKeyFromFile(&http.Transport{}, integrationID, installationID, tmpfile.Name())
+	_, err = NewKeyFromFile(&http.Transport{}, appID, installationID, tmpfile.Name())
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -149,7 +149,7 @@ func TestNew_appendHeader(t *testing.T) {
 	}
 	req.Header.Add("Accept", myheader)
 
-	tr, err := New(&http.Transport{}, integrationID, installationID, key)
+	tr, err := New(&http.Transport{}, appID, installationID, key)
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}


### PR DESCRIPTION
GitHub App documentation uses the the term `app ID` in its docs. This
changes all references to be consistent with this. See
https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app
for an example.