### PR TITLE
Update transport_test.go

### DIFF
--- a/transport_test.go
+++ b/transport_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 	
-	"github.com/google/gocmp/cmp"
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-github/github"
 )
 


### PR DESCRIPTION
Fix 'github.com/google/gocmp/cmp' -> 'github.com/google/go-cmp/cmp'