### PR TITLE
Fix API BaseURL when use NewFromAppsTransport

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,5 @@
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
-github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -12,7 +11,6 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90Pveol
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
-golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/transport.go
+++ b/transport.go
@@ -85,7 +85,7 @@ func New(tr http.RoundTripper, appID, installationID int64, privateKey []byte) (
 // NewFromAppsTransport returns a Transport using an existing *AppsTransport.
 func NewFromAppsTransport(atr *AppsTransport, installationID int64) *Transport {
 	return &Transport{
-		BaseURL:        apiBaseURL,
+		BaseURL:        atr.BaseURL,
 		Client:         &http.Client{Transport: atr.tr},
 		tr:             atr.tr,
 		appID:          atr.appID,


### PR DESCRIPTION
When we create `Transport` using an existing `AppsTransport`, using `NewFromAppsTransport` function. It extracts the necessary  feileds (e.g., `appID` and `tr` ) from `AppsTransport`.

**The issue**: if the BaseURL on `AppsTransport` has been changed (e.g., point to an enterprise server), the `NewFromAppsTransport` function uses the default `apiBaseURL` which is the public Github API.

**Solution**: read the BaseURL from `AppsTransport`.