### PR TITLE
Fix a breakage change in the jwt-go v4 update

### DIFF
--- a/appsTransport.go
+++ b/appsTransport.go
@@ -65,8 +65,8 @@ func NewAppsTransportFromPrivateKey(tr http.RoundTripper, appID int64, key *rsa.
 // RoundTrip implements http.RoundTripper interface.
 func (t *AppsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	claims := &jwt.StandardClaims{
-		IssuedAt:  time.Now().Unix(),
-		ExpiresAt: time.Now().Add(time.Minute).Unix(),
+		IssuedAt:  jwt.Now(),
+		ExpiresAt: jwt.At(time.Now().Add(time.Minute)),
 		Issuer:    strconv.FormatInt(t.appID, 10),
 	}
 	bearer := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)


### PR DESCRIPTION
The package is not compiling. The package `dgrijalva/jwt-go` got updated to v4. However, the new version changes the type for the claim's time form `int64` to `jwt.Time`.

```
 % go test
# github.com/bradleyfalzon/ghinstallation [github.com/bradleyfalzon/ghinstallation.test]
./appsTransport.go:68:3: cannot use time.Now().Unix() (type int64) as type *jwt.Time in field value
./appsTransport.go:69:3: cannot use time.Now().Add(time.Minute).Unix() (type int64) as type *jwt.Time in field value
FAIL    github.com/bradleyfalzon/ghinstallation [build failed]
```

Such bug could be caught by running the tests. I suggest utilizing the Github Actions to build and run the tests on each commit. I can submit a pull request to setup the Github Actions if you agree to do so.  
