### PR TITLE
Ability to set Transport token

### DIFF
--- a/appsTransport.go
+++ b/appsTransport.go
@@ -65,8 +65,8 @@ func NewAppsTransportFromPrivateKey(tr http.RoundTripper, appID int64, key *rsa.
 // RoundTrip implements http.RoundTripper interface.
 func (t *AppsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	claims := &jwt.StandardClaims{
-		IssuedAt:  time.Now().Unix(),
-		ExpiresAt: time.Now().Add(time.Minute).Unix(),
+		IssuedAt:  jwt.Now(),
+		ExpiresAt: jwt.At(time.Now().Add(time.Minute)),
 		Issuer:    strconv.FormatInt(t.appID, 10),
 	}
 	bearer := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)

--- a/transport.go
+++ b/transport.go
@@ -38,11 +38,11 @@ type Transport struct {
 	appsTransport            *AppsTransport
 
 	mu    *sync.Mutex  // mu protects token
-	token *accessToken // token is the installation's access token
+	token *AccessToken // token is the installation's access token
 }
 
-// accessToken is an installation access token response from GitHub
-type accessToken struct {
+// AccessToken is an installation access token response from GitHub
+type AccessToken struct {
 	Token        string                         `json:"token"`
 	ExpiresAt    time.Time                      `json:"expires_at"`
 	Permissions  github.InstallationPermissions `json:"permissions,omitempty"`
@@ -188,4 +188,11 @@ func GetReadWriter(i interface{}) (io.ReadWriter, error) {
 		}
 	}
 	return buf, nil
+}
+
+// SetToken sets the underlying Transport AccessToken.
+func (t *Transport) SetToken(tok AccessToken) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.token = &tok
 }

--- a/transport_test.go
+++ b/transport_test.go
@@ -212,7 +212,7 @@ func TestRefreshTokenWithParameters(t *testing.T) {
 			}
 
 			// Return acceptable access token.
-			AccessToken := AccessToken{
+			accessToken := AccessToken{
 				Token:     "token_string",
 				ExpiresAt: time.Now(),
 				Repositories: []github.Repository{{
@@ -223,7 +223,7 @@ func TestRefreshTokenWithParameters(t *testing.T) {
 					Issues:   github.String("read"),
 				},
 			}
-			tokenReadWriter, err := GetReadWriter(AccessToken)
+			tokenReadWriter, err := GetReadWriter(accessToken)
 			if err != nil {
 				return nil, fmt.Errorf("error converting token into io.ReadWriter: %+v", err)
 			}

--- a/transport_test.go
+++ b/transport_test.go
@@ -58,7 +58,7 @@ func TestNew(t *testing.T) {
 		switch r.RequestURI {
 		case fmt.Sprintf("/app/installations/%d/access_tokens", installationID):
 			// respond with any token to installation transport
-			js, _ := json.Marshal(accessToken{
+			js, _ := json.Marshal(AccessToken{
 				Token:     token,
 				ExpiresAt: time.Now().Add(5 * time.Minute),
 			})
@@ -212,7 +212,7 @@ func TestRefreshTokenWithParameters(t *testing.T) {
 			}
 
 			// Return acceptable access token.
-			accessToken := accessToken{
+			AccessToken := AccessToken{
 				Token:     "token_string",
 				ExpiresAt: time.Now(),
 				Repositories: []github.Repository{{
@@ -223,7 +223,7 @@ func TestRefreshTokenWithParameters(t *testing.T) {
 					Issues:   github.String("read"),
 				},
 			}
-			tokenReadWriter, err := GetReadWriter(accessToken)
+			tokenReadWriter, err := GetReadWriter(AccessToken)
 			if err != nil {
 				return nil, fmt.Errorf("error converting token into io.ReadWriter: %+v", err)
 			}


### PR DESCRIPTION
Add the ability to set the access token on a Transport. This is useful to create a Transport from a token already known (for example stored in a database) to avoid an unnecessary HTTP request to get a new one.

Also fix the build by changing to new jwt time types.