### PR TITLE
Add StatusCode to error message if refreshToken() fails due to an suspended app

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -170,7 +170,7 @@ func (t *Transport) refreshToken(ctx context.Context) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode/100 != 2 {
-		return fmt.Errorf("request %+v received non 2xx response status %q with body %+v and TLS %+v", resp.Request, resp.Body, resp.Request, resp.TLS)
+		return fmt.Errorf("request %+v received non 2xx response status %q with body %+v and TLS %+v", resp.Request, resp.StatusCode, resp.Body, resp.TLS)
 	}
 
 	return json.NewDecoder(resp.Body).Decode(&t.token)

--- a/transport.go
+++ b/transport.go
@@ -170,7 +170,7 @@ func (t *Transport) refreshToken(ctx context.Context) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode/100 != 2 {
-		return fmt.Errorf("request %+v received non 2xx response status %q with body %+v and TLS %+v", resp.Request, resp.StatusCode, resp.Body, resp.TLS)
+		return fmt.Errorf("received non 2xx response status %q when fetching %v", resp.Status, req.URL)
 	}
 
 	return json.NewDecoder(resp.Body).Decode(&t.token)


### PR DESCRIPTION
If a GitHub App is suspended, the refreshToken() roundtrip will return a 403 HTTP Status Code.
In the error message, this is not visible.

This PR is doing a small quick fix to add the Status code into the error message

### Better solution

A better solution would be to include the full response for inspection into the error.
For this, we would need a custom error type.

@bradleyfalzon @wlynch Would you be open to such a PR?