### PR TITLE
Introduce a custom error for refreshToken operation

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -178,7 +178,6 @@ func (t *Transport) refreshToken(ctx context.Context) error {
 	t.appsTransport.Client = t.Client
 	resp, err := t.appsTransport.RoundTrip(req)
 	e := &RefreshTokenError{
-		Message:        fmt.Sprintf("received non 2xx response status %q when fetching %v", resp.Status, req.URL),
 		RootCause:      err,
 		InstallationID: t.installationID,
 		Response:       resp,

--- a/transport.go
+++ b/transport.go
@@ -58,7 +58,7 @@ type RefreshTokenError struct {
 	Response       *http.Response
 }
 
-func (e RefreshTokenError) Error() string {
+func (e *RefreshTokenError) Error() string {
 	return e.Message
 }
 
@@ -177,7 +177,7 @@ func (t *Transport) refreshToken(ctx context.Context) error {
 	t.appsTransport.BaseURL = t.BaseURL
 	t.appsTransport.Client = t.Client
 	resp, err := t.appsTransport.RoundTrip(req)
-	e := RefreshTokenError{
+	e := &RefreshTokenError{
 		Message:        fmt.Sprintf("received non 2xx response status %q when fetching %v", resp.Status, req.URL),
 		RootCause:      err,
 		InstallationID: t.installationID,

--- a/transport.go
+++ b/transport.go
@@ -131,14 +131,7 @@ func (t *Transport) Token(ctx context.Context) (string, error) {
 	if t.token == nil || t.token.ExpiresAt.Add(-time.Minute).Before(time.Now()) {
 		// Token is not set or expired/nearly expired, so refresh
 		if err := t.refreshToken(ctx); err != nil {
-			errorMessage := fmt.Sprintf("could not refresh installation id %v's token: %s", t.installationID, err)
-			re, ok := err.(*RefreshTokenError)
-			if ok {
-				re.Message = errorMessage
-				return "", re
-			}
-
-			return "", errors.New(errorMessage)
+	return "", fmt.Errorf("could not refresh installation id %v's token: %w", t.installationID, err)
 		}
 	}
 

--- a/transport.go
+++ b/transport.go
@@ -49,7 +49,7 @@ type accessToken struct {
 	Repositories []github.Repository            `json:"repositories,omitempty"`
 }
 
-// HTTPError represents a custom error for failing HTTP operatins.
+// HTTPError represents a custom error for failing HTTP operations.
 // Example in our usecase: refresh access token operation.
 // It enables the caller to inspect the root cause and response.
 type HTTPError struct {

--- a/transport.go
+++ b/transport.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -56,7 +55,6 @@ type RefreshTokenError struct {
 	Message        string
 	RootCause      error
 	InstallationID int64
-	Request        *http.Request
 	Response       *http.Response
 }
 
@@ -131,7 +129,7 @@ func (t *Transport) Token(ctx context.Context) (string, error) {
 	if t.token == nil || t.token.ExpiresAt.Add(-time.Minute).Before(time.Now()) {
 		// Token is not set or expired/nearly expired, so refresh
 		if err := t.refreshToken(ctx); err != nil {
-	return "", fmt.Errorf("could not refresh installation id %v's token: %w", t.installationID, err)
+			return "", fmt.Errorf("could not refresh installation id %v's token: %w", t.installationID, err)
 		}
 	}
 
@@ -183,7 +181,6 @@ func (t *Transport) refreshToken(ctx context.Context) error {
 		Message:        fmt.Sprintf("received non 2xx response status %q when fetching %v", resp.Status, req.URL),
 		RootCause:      err,
 		InstallationID: t.installationID,
-		Request:        req,
 		Response:       resp,
 	}
 	if err != nil {

--- a/transport.go
+++ b/transport.go
@@ -187,12 +187,13 @@ func (t *Transport) refreshToken(ctx context.Context) error {
 		e.Message = fmt.Sprintf("could not get access_tokens from GitHub API for installation ID %v: %v", t.installationID, err)
 		return e
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode/100 != 2 {
 		e.Message = fmt.Sprintf("received non 2xx response status %q when fetching %v", resp.Status, req.URL)
 		return e
 	}
+	// Closing body late, to provide caller a chance to inspect body in an error / non-200 response status situation
+	defer resp.Body.Close()
 
 	return json.NewDecoder(resp.Body).Decode(&t.token)
 }

--- a/transport.go
+++ b/transport.go
@@ -49,16 +49,17 @@ type accessToken struct {
 	Repositories []github.Repository            `json:"repositories,omitempty"`
 }
 
-// RefreshTokenError represents a custom error for the refresh access tokens operations.
+// HTTPError represents a custom error for failing HTTP operatins.
+// Example in our usecase: refresh access token operation.
 // It enables the caller to inspect the root cause and response.
-type RefreshTokenError struct {
+type HTTPError struct {
 	Message        string
 	RootCause      error
 	InstallationID int64
 	Response       *http.Response
 }
 
-func (e *RefreshTokenError) Error() string {
+func (e *HTTPError) Error() string {
 	return e.Message
 }
 
@@ -177,7 +178,7 @@ func (t *Transport) refreshToken(ctx context.Context) error {
 	t.appsTransport.BaseURL = t.BaseURL
 	t.appsTransport.Client = t.Client
 	resp, err := t.appsTransport.RoundTrip(req)
-	e := &RefreshTokenError{
+	e := &HTTPError{
 		RootCause:      err,
 		InstallationID: t.installationID,
 		Response:       resp,


### PR DESCRIPTION
**What type of PR is this?**

feature

**What this PR does / why we need it**:

If the refreshToken operation fails (e.g., the GitHub app has been suspended), the RoundTrip is returning an error. However, the caller is not able to figure out the root cause of the failure.
This commit introduces a custom error that contains the original request and response for further inspection.

**Special notes for your reviewer**:

This PR was mentioned shortly in https://github.com/bradleyfalzon/ghinstallation/pull/44 with @wlynch 

**Does this PR introduce a user-facing change?**:

None

**Additional documentation e.g., usage docs, etc.**:

None