### PR TITLE
Truncate issue and expiry times to whole seconds

### DIFF
--- a/appsTransport.go
+++ b/appsTransport.go
@@ -64,9 +64,14 @@ func NewAppsTransportFromPrivateKey(tr http.RoundTripper, appID int64, key *rsa.
 
 // RoundTrip implements http.RoundTripper interface.
 func (t *AppsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// GitHub rejects expiry and issue timestamps that are not an integer,
+	// while the jwt-go library serializes to fractional timestamps.
+	// Truncate them before passing to jwt-go.
+	iss := time.Now().Add(-30 * time.Second).Truncate(time.Second)
+	exp := iss.Add(2 * time.Minute)
 	claims := &jwt.StandardClaims{
-		IssuedAt:  jwt.Now(),
-		ExpiresAt: jwt.At(time.Now().Add(time.Minute)),
+		IssuedAt:  jwt.At(iss),
+		ExpiresAt: jwt.At(exp),
 		Issuer:    strconv.FormatInt(t.appID, 10),
 	}
 	bearer := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)

--- a/appsTransport_test.go
+++ b/appsTransport_test.go
@@ -6,8 +6,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
+	jwt "github.com/dgrijalva/jwt-go/v4"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -60,6 +63,39 @@ func TestAppsTransport(t *testing.T) {
 		t.Fatalf("error creating transport: %v", err)
 	}
 
+	req := httptest.NewRequest(http.MethodGet, "http://example.com", new(bytes.Buffer))
+	req.Header.Add("Accept", customHeader)
+	if _, err := tr.RoundTrip(req); err != nil {
+		t.Fatalf("error calling RoundTrip: %v", err)
+	}
+}
+
+func TestJWTExpiry(t *testing.T) {
+	key, err := jwt.ParseRSAPrivateKeyFromPEM(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	customHeader := "my-header"
+	check := RoundTrip{
+		rt: func(req *http.Request) (*http.Response, error) {
+			token := strings.Fields(req.Header.Get("Authorization"))[1]
+			tok, err := jwt.ParseWithClaims(token, &jwt.StandardClaims{}, jwt.KnownKeyfunc(jwt.SigningMethodRS256, key))
+			if err != nil {
+				t.Fatalf("jwt parse: %v", err)
+			}
+
+			c := tok.Claims.(*jwt.StandardClaims)
+			if c.ExpiresAt == nil {
+				t.Fatalf("missing exp claim")
+			} else if c.ExpiresAt.Time != c.ExpiresAt.Truncate(time.Second) {
+				t.Fatalf("bad exp %v: not truncated to whole seconds", c.ExpiresAt.Time)
+			}
+			return nil, nil
+		},
+	}
+
+	tr := NewAppsTransportFromPrivateKey(check, appID, key)
 	req := httptest.NewRequest(http.MethodGet, "http://example.com", new(bytes.Buffer))
 	req.Header.Add("Accept", customHeader)
 	if _, err := tr.RoundTrip(req); err != nil {


### PR DESCRIPTION
GitHub is rejecting JWTs whose expiry timestamps
have fractional seconds with the error:

	Expiration time' claim ('exp') must be a numeric value representing
	the future time at which the assertion expires

Whereas jwt-go supports fractional seconds, and therefore serializes
timestamps truncated to microsecond resolution.

This change truncates the timestamps before passing to jwt-go
which fixes the issue.