### PR TITLE
Replace "machine-man-preview" header with "application/vnd.github.v3+json"

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -15,8 +15,7 @@ import (
 )
 
 const (
-	// acceptHeader is the GitHub Apps Preview Accept header.
-	acceptHeader = "application/vnd.github.machine-man-preview+json"
+	acceptHeader = "application/vnd.github.v3+json"
 	apiBaseURL   = "https://api.github.com"
 )
 


### PR DESCRIPTION
The header `application/vnd.github.machine-man-preview+json` graduated in August 2020.
See https://developer.github.com/changes/2020-08-20-graduate-machine-man-and-sailor-v-previews/

According to the API docs [Create an installation access token for an app](https://docs.github.com/en/rest/reference/apps#create-an-installation-access-token-for-an-app), the header `application/vnd.github.v3+json` is suggested.