### PR TITLE
Upgrade go-github from v30.0.0 to v35.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.13
 require (
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
 	github.com/google/go-cmp v0.4.0
-	github.com/google/go-github/v30 v30.0.0
+	github.com/google/go-github/v35 v35.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1/go.mod h1:+hnT3ywWDTAFrW5aE+u2Sa/
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-github/v30 v30.0.0 h1:5UgIxLcf4zolLP8QpFcrSku0G1Y/p5+WChWL11dFlnQ=
-github.com/google/go-github/v30 v30.0.0/go.mod h1:n8jBpHl45a/rlBUtRJMOG4GhNADUQFEufcolZ95JfU8=
+github.com/google/go-github/v35 v35.1.0 h1:KkwZnKWQ/0YryvXjZlCN/3EGRJNp6VCZPKo+RG9mG28=
+github.com/google/go-github/v35 v35.1.0/go.mod h1:s0515YVTI+IMrDoy9Y4pHt9ShGpzHvHO8rZ7L7acgvs=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=

--- a/transport.go
+++ b/transport.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/go-github/v30/github"
+	"github.com/google/go-github/v35/github"
 )
 
 const (

--- a/transport_test.go
+++ b/transport_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-github/v30/github"
+	"github.com/google/go-github/v35/github"
 )
 
 const (


### PR DESCRIPTION
v35.1.0 (and the versions until v30) contains a lot of bugfixes and additional fields for structs like `Repositories`