### PR TITLE
Bump module version to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ https://developer.github.com/apps/building-integrations/setting-up-and-registeri
 Get the package:
 
 ```bash
-GO111MODULE=on go get -u github.com/bradleyfalzon/ghinstallation
+GO111MODULE=on go get -u github.com/bradleyfalzon/ghinstallation/v2
 ```
 
 # GitHub Example
 
 ```go
-import "github.com/bradleyfalzon/ghinstallation"
+import "github.com/bradleyfalzon/ghinstallation/v2"
 
 func main() {
     // Shared transport to reuse TCP connections.
@@ -44,7 +44,7 @@ func main() {
 For clients using GitHub Enterprise, set the base URL as follows:
 
 ```go
-import "github.com/bradleyfalzon/ghinstallation"
+import "github.com/bradleyfalzon/ghinstallation/v2"
 
 const GitHubEnterpriseURL = "https://github.example.com/api/v3"
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bradleyfalzon/ghinstallation
+module github.com/bradleyfalzon/ghinstallation/v2
 
 go 1.13
 


### PR DESCRIPTION
Resolves #50. When this repo cut a v2 release, it accidentally "broke" the conventions for go modules in v2.

I think this is all that is necessary to fix the issue.

See https://blog.golang.org/v2-go-modules for more details.