### PR TITLE
trim trailing slashes from base url

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -159,7 +160,8 @@ func (t *Transport) refreshToken(ctx context.Context) error {
 		return fmt.Errorf("could not convert installation token parameters into json: %s", err)
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/app/installations/%v/access_tokens", t.BaseURL, t.installationID), body)
+	requestURL := fmt.Sprintf("%s/app/installations/%v/access_tokens", strings.TrimRight(t.BaseURL, "/"), t.installationID)
+	req, err := http.NewRequest("POST", requestURL, body)
 	if err != nil {
 		return fmt.Errorf("could not create request: %s", err)
 	}


### PR DESCRIPTION
When using a custom Github URL (e.g. for a Github Enterprise instance)
one might specify it with a trailing slash. This can lead to URLs
containing two successive slashes.

Github will not ignore this, but instead return a HTTP 401 Forbidden
response. It might be nice to address the issue by removing trailing
slashes when joining with a string that has a leading slash.