### PR TITLE
Respect the http.RoundTripper contract

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -111,14 +111,25 @@ func NewFromAppsTransport(atr *AppsTransport, installationID int64) *Transport {
 
 // RoundTrip implements http.RoundTripper interface.
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	reqBodyClosed := false
+	if req.Body != nil {
+		defer func() {
+			if !reqBodyClosed {
+				req.Body.Close()
+			}
+		}()
+	}
+	
 	token, err := t.Token(req.Context())
 	if err != nil {
 		return nil, err
 	}
 
-	req.Header.Set("Authorization", "token "+token)
-	req.Header.Add("Accept", acceptHeader) // We add to "Accept" header to avoid overwriting existing req headers.
-	resp, err := t.tr.RoundTrip(req)
+	creq := cloneRequest(req) // per RoundTripper contract
+	creq.Header.Set("Authorization", "token "+token)
+	creq.Header.Add("Accept", acceptHeader) // We add to "Accept" header to avoid overwriting existing req headers.
+	reqBodyClosed = true // req.Body is assumed to be closed by the tr RoundTripper.
+	resp, err := t.tr.RoundTrip(creq)
 	return resp, err
 }
 
@@ -211,4 +222,18 @@ func GetReadWriter(i interface{}) (io.ReadWriter, error) {
 		}
 	}
 	return buf, nil
+}
+
+// cloneRequest returns a clone of the provided *http.Request.
+// The clone is a shallow copy of the struct and its Header map.
+func cloneRequest(r *http.Request) *http.Request {
+	// shallow copy of the struct
+	r2 := new(http.Request)
+	*r2 = *r
+	// deep copy of the Header
+	r2.Header = make(http.Header, len(r.Header))
+	for k, s := range r.Header {
+		r2.Header[k] = append([]string(nil), s...)
+	}
+	return r2
 }


### PR DESCRIPTION
Fixes #20 

Without this, it's impossible to use [`httpcache`](https://github.com/gregjones/httpcache) together with this package, as `httpcache` expects the parent RoundTripper to respect the [RoundTripper contract](https://pkg.go.dev/net/http#RoundTripper):

```
	// RoundTrip should not modify the request, except for
	// consuming and closing the Request's Body. RoundTrip may
	// read fields of the request in a separate goroutine. 
```

ghinstallation currently does not comply with the contract, as it modifies the request headers (in addition to not closing the body in case of errors).

As a result of this, no request will ever result in a hit in the cache because ghinstallation modifies some of the request headers that the Github API includes in the Vary response header (Accept, Authorization).

As a hacky workaround until this bug is fixed in ghinstallation, you can add an intermediate roundtripper between httpcache and ghinstallation to clone the request, so that ghinstallation modifies the clone instead of the request passed by httpcache:

```
	// itr is the ghinstallation RoundTripper

	dtr := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
		return itr.RoundTrip(req.Clone(req.Context()))
	})

	// use dtr as the Transport for httpcache
```