### PR TITLE
Expose when the installation token expires

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -148,6 +148,14 @@ func (t *Transport) Token(ctx context.Context) (string, error) {
 	return t.token.Token, nil
 }
 
+// ExpiresAt returns when the transport token expires.
+func (t *Transport) ExpiresAt() (time.Time) {
+	if t.token == nil {
+		return nil
+	}
+	return t.token.ExpiresAt
+}
+
 // Permissions returns a transport token's GitHub installation permissions.
 func (t *Transport) Permissions() (github.InstallationPermissions, error) {
 	if t.token == nil {

--- a/transport.go
+++ b/transport.go
@@ -149,11 +149,11 @@ func (t *Transport) Token(ctx context.Context) (string, error) {
 }
 
 // ExpiresAt returns when the transport token expires.
-func (t *Transport) ExpiresAt() (time.Time) {
+func (t *Transport) ExpiresAt() (time.Time, error) {
 	if t.token == nil {
-		return nil
+		return time.Time{}, fmt.Errorf("ExpiresAt() = nil, err: nil token")
 	}
-	return t.token.ExpiresAt
+	return t.token.ExpiresAt, nil
 }
 
 // Permissions returns a transport token's GitHub installation permissions.


### PR DESCRIPTION
It can be very convenient to know when the installation token expires. It is stored in an internal field, so without this method we can not get to the ExpiresAt value.