### PR TITLE
Allow JWT signing method to be configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,26 @@ WebHook request
   }
 ```
 
+# Customizing signing behavior
+
+Users can customize signing behavior by passing in a
+[Signer](https://pkg.go.dev/github.com/bradleyfalzon/ghinstallation/v2#Signer)
+implementation when creating an
+[AppsTransport](https://pkg.go.dev/github.com/bradleyfalzon/ghinstallation/v2#AppsTransport).
+For example, this can be used to create tokens backed by keys in a KMS system.
+
+```go
+signer := &myCustomSigner{
+  key: "https://url/to/key/vault",
+}
+atr := NewAppsTransportWithOptions(http.DefaultTransport, 1, WithSigner(signer))
+tr := NewFromAppsTransport(atr, 99)
+```
+
 # License
 
 [Apache 2.0](LICENSE)
 
 # Dependencies
 
--   [github.com/golang-jwt/jwt-go](https://github.com/golang-jwt/jwt-go)
+- [github.com/golang-jwt/jwt-go](https://github.com/golang-jwt/jwt-go)

--- a/sign.go
+++ b/sign.go
@@ -1,0 +1,33 @@
+package ghinstallation
+
+import (
+	"crypto/rsa"
+
+	jwt "github.com/golang-jwt/jwt/v4"
+)
+
+// Signer is a JWT token signer. This is a wrapper around [jwt.SigningMethod] with predetermined
+// key material.
+type Signer interface {
+	// Sign signs the given claims and returns a JWT token string, as specified
+	// by [jwt.Token.SignedString]
+	Sign(claims jwt.Claims) (string, error)
+}
+
+// RSASigner signs JWT tokens using RSA keys.
+type RSASigner struct {
+	method *jwt.SigningMethodRSA
+	key    *rsa.PrivateKey
+}
+
+func NewRSASigner(method *jwt.SigningMethodRSA, key *rsa.PrivateKey) *RSASigner {
+	return &RSASigner{
+		method: method,
+		key:    key,
+	}
+}
+
+// Sign signs the JWT claims with the RSA key.
+func (s *RSASigner) Sign(claims jwt.Claims) (string, error) {
+	return jwt.NewWithClaims(s.method, claims).SignedString(s.key)
+}


### PR DESCRIPTION
This change creates a new `Signer` interface which encapsulates jwt.SigningMethod + the key material use to sign JWT tokens.

This allows clients to modify how JWT tokens are signed by passing in their own Signer. In particular, I'm interested in coupling this with something like
https://github.com/golang-jwt/jwt#extensions to allow for JWT signing backed by KMS systems (Vault, Cloud KMS, etc) where the private key never resides on the local client.

Introduces a new `AppsTransportOptions` to make it easier to make new transport creation options without needing to make new funcs each time. For now only added `WithSigner`, but we could easily extend this out to other config options (Client, BaseURL, etc.)

Finally, upgrades deprecated `jwt.StandardClaims` -> `jwt.RegisteredClaims`.