### PR TITLE
Prevent adding Accept header when already one.

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -119,7 +119,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 			}
 		}()
 	}
-	
+
 	token, err := t.Token(req.Context())
 	if err != nil {
 		return nil, err
@@ -127,7 +127,10 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	creq := cloneRequest(req) // per RoundTripper contract
 	creq.Header.Set("Authorization", "token "+token)
-	creq.Header.Add("Accept", acceptHeader) // We add to "Accept" header to avoid overwriting existing req headers.
+
+	if creq.Header.Get("Accept") == "" { // We only add an "Accept" header to avoid overwriting the expected behavior.
+		creq.Header.Add("Accept", acceptHeader)
+	}
 	reqBodyClosed = true // req.Body is assumed to be closed by the tr RoundTripper.
 	resp, err := t.tr.RoundTrip(creq)
 	return resp, err

--- a/transport_test.go
+++ b/transport_test.go
@@ -177,6 +177,18 @@ func TestNew_appendHeader(t *testing.T) {
 	if !found {
 		t.Errorf("could not find %v in request's accept headers: %v", myheader, headers["Accept"])
 	}
+
+	// Here we test that there isn't a second Accept header.
+	// Though the Accept header 'application/vnd.github.v3+json' is used for most
+	//  interactions with the GitHub API, having this header will force the
+	//  GitHub API response as JSON, which we don't want when downloading a
+	//  release (octet-stream)
+	for _, v := range headers["Accept"] {
+		if v == acceptHeader {
+			t.Errorf("accept header '%s' should not be present when accept header '%s' is set: %v", acceptHeader, myheader, headers["Accept"])
+			break
+		}
+	}
 }
 
 func TestRefreshTokenWithParameters(t *testing.T) {


### PR DESCRIPTION
This change prevents the Accept header `application/vnd.github.v3+json` from being added to the headers in case there is already an Accept header.

The mentioned header is necessary for most interactions with the GitHub API, but it also influence the behaviour of some resource call in an unexpected way.

Example:
When downloading a release with the [go-github](https://github.com/google/go-github) library, an Accept header `application/octet-stream` is added by the latter, then ghinstallation adds the Accept header `application/vnd.github.v3+json`.
The response to such request isn't the content of the release, as one could expect when using the function `DownloadReleaseAsset` but a json describing the release.

This PR prevents this behaviour from happening and tackle the issue #12 