### PR TITLE
Add Transport.Expiry() to query token expiration

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -136,12 +137,16 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return resp, err
 }
 
+func (at *accessToken) isExpired() bool {
+	return at == nil || at.ExpiresAt.Add(-time.Minute).Before(time.Now())
+}
+
 // Token checks the active token expiration and renews if necessary. Token returns
 // a valid access token. If renewal fails an error is returned.
 func (t *Transport) Token(ctx context.Context) (string, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	if t.token == nil || t.token.ExpiresAt.Add(-time.Minute).Before(time.Now()) {
+	if t.token.isExpired() {
 		// Token is not set or expired/nearly expired, so refresh
 		if err := t.refreshToken(ctx); err != nil {
 			return "", fmt.Errorf("could not refresh installation id %v's token: %w", t.installationID, err)
@@ -165,6 +170,14 @@ func (t *Transport) Repositories() ([]github.Repository, error) {
 		return nil, fmt.Errorf("Repositories() = nil, err: nil token")
 	}
 	return t.token.Repositories, nil
+}
+
+// Expiry returns a transport token's expiration time and current expiration status.
+func (t *Transport) Expiry() (expiresAt time.Time, expired bool, err error) {
+	if t.token == nil {
+		return time.Time{}, true, errors.New("Expiry() = unknown, err: nil token")
+	}
+	return t.token.ExpiresAt, t.token.isExpired(), nil
 }
 
 func (t *Transport) refreshToken(ctx context.Context) error {


### PR DESCRIPTION
Since it could be interesting in some cases, return this for the user to examine.

Also factor out the "is a token expired" logic and return the current value of "we think it's expired" when calling Expiry().

    expiresAt, expired, err := trans.Expiry()