### PR TITLE
HTTPError should be unwrappable.

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -64,6 +64,7 @@ func (e *HTTPError) Error() string {
 	return e.Message
 }
 
+// Unwrap implements the standard library's error wrapping. It unwraps to the root cause.
 func (e *HTTPError) Unwrap() error {
 	return e.RootCause
 }

--- a/transport.go
+++ b/transport.go
@@ -64,6 +64,10 @@ func (e *HTTPError) Error() string {
 	return e.Message
 }
 
+func (e *HTTPError) Unwrap() error {
+	return e.RootCause
+}
+
 var _ http.RoundTripper = &Transport{}
 
 // NewKeyFromFile returns a Transport using a private key from file.

--- a/transport_test.go
+++ b/transport_test.go
@@ -3,6 +3,7 @@ package ghinstallation
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -451,5 +452,17 @@ func TestExpiryAccessor(t *testing.T) {
 					tc.expectRefresh, refreshAt)
 			}
 		})
+	}
+}
+
+func TestHTTPErrorUnwrap(t *testing.T) {
+	wrappedError := errors.New("wrapped error")
+
+	err := &HTTPError{
+		RootCause: wrappedError,
+	}
+
+	if !errors.Is(err, wrappedError) {
+		t.Errorf("HTTPError should be unwrapped to the root cause")
 	}
 }


### PR DESCRIPTION
Hey @bradleyfalzon!

Thanks for creating https://github.com/bradleyfalzon/ghinstallation!

An issue we've been having is that, when using a custom http client underneath ghinstallation and returning special error types from it, ghinstallation wraps them in HTTPError which we can't unwrap using errors.As.

Would you consider accepting this fix upstream?