### PR TITLE
feat: add ID getter methods

### DIFF
--- a/appsTransport.go
+++ b/appsTransport.go
@@ -106,6 +106,11 @@ func (t *AppsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return resp, err
 }
 
+// AppID returns the appID of the transport
+func (t *AppsTransport) AppID() int64 {
+	return t.appID
+}
+
 type AppsTransportOption func(*AppsTransport)
 
 // WithSigner configures the AppsTransport to use the given Signer for generating JWT tokens.

--- a/appsTransport_test.go
+++ b/appsTransport_test.go
@@ -63,6 +63,10 @@ func TestAppsTransport(t *testing.T) {
 		t.Fatalf("error creating transport: %v", err)
 	}
 
+	if tr.appID != appID {
+		t.Errorf("appID want->got: %d->%d", appID, tr.appID)
+	}
+
 	req := httptest.NewRequest(http.MethodGet, "http://example.com", new(bytes.Buffer))
 	req.Header.Add("Accept", customHeader)
 	if _, err := tr.RoundTrip(req); err != nil {

--- a/transport.go
+++ b/transport.go
@@ -191,6 +191,16 @@ func (t *Transport) Expiry() (expiresAt time.Time, refreshAt time.Time, err erro
 	return t.token.ExpiresAt, t.token.getRefreshTime(), nil
 }
 
+// AppID returns the app ID associated with the transport
+func (t *Transport) AppID() int64 {
+	return t.appID
+}
+
+// InstallationID returns the installation ID associated with the transport
+func (t *Transport) InstallationID() int64 {
+	return t.installationID
+}
+
 func (t *Transport) refreshToken(ctx context.Context) error {
 	// Convert InstallationTokenOptions into a ReadWriter to pass as an argument to http.NewRequest.
 	body, err := GetReadWriter(t.InstallationTokenOptions)

--- a/transport_test.go
+++ b/transport_test.go
@@ -83,6 +83,15 @@ func TestNew(t *testing.T) {
 	}
 	tr.BaseURL = ts.URL
 
+	// test id getter methods
+	if tr.AppID() != appID {
+		t.Fatalf("appID got: %q want: %q", tr.AppID(), appID)
+	}
+
+	if tr.InstallationID() != installationID {
+		t.Fatalf("installationID got: %q want: %q", tr.InstallationID(), installationID)
+	}
+
 	client := http.Client{Transport: tr}
 	_, err = client.Get(ts.URL + "/auth/with/installation/token/endpoint")
 	if err != nil {


### PR DESCRIPTION
Without this, it is not possible to know which app or installation a given transport is for without tracking it separately.

These are getter functions that return copies so they are backwards compatible and cannot cause any issues or break a transport.