### PR TITLE
ioutil deprecations

### DIFF
--- a/appsTransport.go
+++ b/appsTransport.go
@@ -4,8 +4,8 @@ import (
 	"crypto/rsa"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strconv"
 	"time"
 
@@ -30,7 +30,7 @@ type AppsTransport struct {
 
 // NewAppsTransportKeyFromFile returns a AppsTransport using a private key from file.
 func NewAppsTransportKeyFromFile(tr http.RoundTripper, appID int64, privateKeyFile string) (*AppsTransport, error) {
-	privateKey, err := ioutil.ReadFile(privateKeyFile)
+	privateKey, err := os.ReadFile(privateKeyFile)
 	if err != nil {
 		return nil, fmt.Errorf("could not read private key: %s", err)
 	}

--- a/appsTransport_test.go
+++ b/appsTransport_test.go
@@ -83,7 +83,7 @@ func TestJWTExpiry(t *testing.T) {
 	check := RoundTrip{
 		rt: func(req *http.Request) (*http.Response, error) {
 			token := strings.Fields(req.Header.Get("Authorization"))[1]
-			tok, err := jwt.ParseWithClaims(token, &jwt.StandardClaims{}, func(t *jwt.Token) (interface{}, error) {
+			tok, err := jwt.ParseWithClaims(token, &jwt.RegisteredClaims{}, func(t *jwt.Token) (interface{}, error) {
 				if t.Header["alg"] != "RS256" {
 					return nil, fmt.Errorf("unexpected signing method: %v, expected: %v", t.Header["alg"], "RS256")
 				}
@@ -93,8 +93,8 @@ func TestJWTExpiry(t *testing.T) {
 				t.Fatalf("jwt parse: %v", err)
 			}
 
-			c := tok.Claims.(*jwt.StandardClaims)
-			if c.ExpiresAt == 0 {
+			c := tok.Claims.(*jwt.RegisteredClaims)
+			if c.ExpiresAt.IsZero() {
 				t.Fatalf("missing exp claim")
 			}
 			return nil, nil

--- a/appsTransport_test.go
+++ b/appsTransport_test.go
@@ -3,7 +3,6 @@ package ghinstallation
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -15,7 +14,7 @@ import (
 )
 
 func TestNewAppsTransportKeyFromFile(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "example")
+	tmpfile, err := os.CreateTemp("", "example")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/bradleyfalzon/ghinstallation/v2
 
-go 1.13
+go 1.21
+
+toolchain go1.22.0
 
 require (
 	github.com/golang-jwt/jwt/v4 v4.5.0

--- a/transport.go
+++ b/transport.go
@@ -7,8 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -73,7 +73,7 @@ var _ http.RoundTripper = &Transport{}
 
 // NewKeyFromFile returns a Transport using a private key from file.
 func NewKeyFromFile(tr http.RoundTripper, appID, installationID int64, privateKeyFile string) (*Transport, error) {
-	privateKey, err := ioutil.ReadFile(privateKeyFile)
+	privateKey, err := os.ReadFile(privateKeyFile)
 	if err != nil {
 		return nil, fmt.Errorf("could not read private key: %s", err)
 	}

--- a/transport_test.go
+++ b/transport_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -129,7 +129,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestNewKeyFromFile(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "example")
+	tmpfile, err := os.CreateTemp("", "example")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -226,8 +226,8 @@ func TestRefreshTokenWithParameters(t *testing.T) {
 		rt: func(req *http.Request) (*http.Response, error) {
 			// Convert io.ReadCloser to String without deleting body data.
 			var gotBodyBytes []byte
-			gotBodyBytes, _ = ioutil.ReadAll(req.Body)
-			req.Body = ioutil.NopCloser(bytes.NewBuffer(gotBodyBytes))
+			gotBodyBytes, _ = io.ReadAll(req.Body)
+			req.Body = io.NopCloser(bytes.NewBuffer(gotBodyBytes))
 			gotBodyString := string(gotBodyBytes)
 
 			// Compare request sent with request received.
@@ -251,7 +251,7 @@ func TestRefreshTokenWithParameters(t *testing.T) {
 			if err != nil {
 				return nil, fmt.Errorf("error converting token into io.ReadWriter: %+v", err)
 			}
-			tokenBody := ioutil.NopCloser(tokenReadWriter)
+			tokenBody := io.NopCloser(tokenReadWriter)
 			return &http.Response{
 				Body:       tokenBody,
 				StatusCode: 200,
@@ -295,22 +295,22 @@ func TestRefreshTokenWithTrailingSlashBaseURL(t *testing.T) {
 		rt: func(req *http.Request) (*http.Response, error) {
 			if strings.Contains(req.URL.Path, "//") {
 				return &http.Response{
-					Body:       ioutil.NopCloser(strings.NewReader("Forbidden\n")),
+					Body:       io.NopCloser(strings.NewReader("Forbidden\n")),
 					StatusCode: 401,
 				}, fmt.Errorf("Got simulated 401 Github Forbidden response")
 			}
 
 			if req.URL.Path == "test_endpoint/" && req.Header.Get("Authorization") == fmt.Sprintf("token %s", tokenToBe) {
 				return &http.Response{
-					Body:       ioutil.NopCloser(strings.NewReader("Beautiful\n")),
+					Body:       io.NopCloser(strings.NewReader("Beautiful\n")),
 					StatusCode: 200,
 				}, nil
 			}
 
 			// Convert io.ReadCloser to String without deleting body data.
 			var gotBodyBytes []byte
-			gotBodyBytes, _ = ioutil.ReadAll(req.Body)
-			req.Body = ioutil.NopCloser(bytes.NewBuffer(gotBodyBytes))
+			gotBodyBytes, _ = io.ReadAll(req.Body)
+			req.Body = io.NopCloser(bytes.NewBuffer(gotBodyBytes))
 			gotBodyString := string(gotBodyBytes)
 
 			// Compare request sent with request received.
@@ -334,7 +334,7 @@ func TestRefreshTokenWithTrailingSlashBaseURL(t *testing.T) {
 			if err != nil {
 				return nil, fmt.Errorf("error converting token into io.ReadWriter: %+v", err)
 			}
-			tokenBody := ioutil.NopCloser(tokenReadWriter)
+			tokenBody := io.NopCloser(tokenReadWriter)
 			return &http.Response{
 				Body:       tokenBody,
 				StatusCode: 200,


### PR DESCRIPTION
The Go standard library's `ioutil` package is deprecated. This updates those usages to either `io` or `os` package functions. 

It also updates a test-only usage of the `jwt.StandardClaims` to `jwt.RegisteredClaims`. 