### PR TITLE
Updates go.mod / ci / dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      gomod:
+        update-types:
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,17 @@
 version: 2
 updates:
-- package-ecosystem: gomod
-  directory: /
-  schedule:
-    interval: weekly
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      actions:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,14 +10,20 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        go-version: ['1.21', '1.22']
+
     steps:
-      - name: Set up Go 1.17
-        uses: actions/setup-go@v2
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: 1.17
+          go-version: ${{ matrix.go-version }}
+          check-latest: true
 
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
       - name: Get dependencies
         run: go get -v -t -d ./...

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/bradleyfalzon/ghinstallation/v2
 
-go 1.21
-
-toolchain go1.22.3
+go 1.16
 
 require (
 	github.com/golang-jwt/jwt/v4 v4.5.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/bradleyfalzon/ghinstallation/v2
 
-go 1.16
+go 1.21
+
+toolchain go1.22.3
 
 require (
 	github.com/golang-jwt/jwt/v4 v4.5.0
@@ -8,4 +10,7 @@ require (
 	github.com/google/go-github/v62 v62.0.0
 )
 
-require github.com/google/go-querystring v1.1.0 // indirect
+require (
+	github.com/google/go-querystring v1.1.0 // indirect
+	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
+)


### PR DESCRIPTION
- update go mod to go1.21
- update ci actions and test with supported go versions
- add dependabot config for github actions