### PR TITLE
test/build with go1.23

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,11 @@ name: Go
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
   pull_request:
-    branches: [master]
+    branches:
+      - master
 
 jobs:
   build:
@@ -13,7 +15,10 @@ jobs:
 
     strategy:
       matrix:
-        go-version: ['1.21', '1.22']
+        go-version:
+          - '1.21'
+          - '1.22'
+          - '1.23'
 
     steps:
       - name: Set up Go ${{ matrix.go-version }}


### PR DESCRIPTION
cc @wlynch 


note: we should consider to bump min go to 1.22 and drop go1.21