### PR TITLE
chore: add `go1.24-rc1` for matrix check

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,6 +19,7 @@ jobs:
           - '1.21'
           - '1.22'
           - '1.23'
+          - '1.24.0-rc.1'
 
     steps:
       - name: Set up Go ${{ matrix.go-version }}


### PR DESCRIPTION
- remove go1.21 as only latest two go release lines are maintained by go team
- test out go1.24rc1